### PR TITLE
Adding file argument

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,9 @@
+pyblish-standalone Changelog
+======================
+
+This contains all changes between pyblish-standalone releases.
+
+Version 0.1.0
+-------------
+
+- Initial release

--- a/pyblish_standalone/__main__.py
+++ b/pyblish_standalone/__main__.py
@@ -9,7 +9,7 @@ import pyblish_standalone
 
 
 def cli():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog="pyblish_standalone")
 
     parser.add_argument("file", nargs="?",
                         help="Pass file to Context as `currentFile`")

--- a/pyblish_standalone/__main__.py
+++ b/pyblish_standalone/__main__.py
@@ -10,6 +10,9 @@ import pyblish_standalone
 
 def cli():
     parser = argparse.ArgumentParser()
+
+    parser.add_argument("file", nargs="?",
+                        help="Pass file to Context as `currentFile`")
     parser.add_argument("-d", "--data", nargs=2, action="append",
                         metavar=("key", "value"),
                         help=("Append data to context, "

--- a/pyblish_standalone/plugins/collect_data.py
+++ b/pyblish_standalone/plugins/collect_data.py
@@ -10,7 +10,10 @@ class CollectData(pyblish.api.Collector):
     def process(self, context):
         self.log.info("Adding data from command-line into Context..")
 
-        data = dict(pyblish_standalone.kwargs.get("data") or {})
+        kwargs = pyblish_standalone.kwargs.copy()
+        context.set_data("currentFile", kwargs.get("file"))
+
+        data = dict(kwargs.get("data") or {})
         for key, value in data.iteritems():
             self.log.info("%s = %s" % (key, value))
             context.set_data(key, value)

--- a/pyblish_standalone/plugins/collect_data.py
+++ b/pyblish_standalone/plugins/collect_data.py
@@ -1,3 +1,4 @@
+import os
 import pyblish.api
 import pyblish_standalone
 
@@ -11,7 +12,9 @@ class CollectData(pyblish.api.Collector):
         self.log.info("Adding data from command-line into Context..")
 
         kwargs = pyblish_standalone.kwargs.copy()
-        context.set_data("currentFile", kwargs.get("file"))
+        fname = os.path.abspath(kwargs.get("file"))
+        self.log.info("Adding filename: %s" % fname)
+        context.set_data("currentFile", fname)
 
         data = dict(kwargs.get("data") or {})
         for key, value in data.iteritems():

--- a/pyblish_standalone/version.py
+++ b/pyblish_standalone/version.py
@@ -1,0 +1,10 @@
+
+VERSION_MAJOR = 0
+VERSION_MINOR = 1
+VERSION_PATCH = 0
+
+version_info = (VERSION_MAJOR, VERSION_MINOR, VERSION_PATCH)
+version = '%i.%i.%i' % version_info
+__version__ = version
+
+__all__ = ['version', 'version_info', '__version__']


### PR DESCRIPTION
Files can now be passed directly to the pyblish_standalone command.

``` bash
$ python -m pyblish_standalone path/to/myfile.mb
```

The absolute path to the file is stored as `currentFile` in Context.
